### PR TITLE
Override RSpec/ContextWording

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -414,6 +414,14 @@ Performance/TimesMap:
 RSpec/AnyInstance:
   Enabled: false
 
+RSpec/ContextWording:
+  Prefixes:
+    - when
+    - with
+    - without
+    - and
+    - but
+
 RSpec/DescribeClass:
   Exclude:
     - 'spec/system/**/*'


### PR DESCRIPTION
Allow "and" and "but" as well as the default prefixes. This is backed by the following discussion in _betterspecs_: https://github.com/betterspecs/betterspecs/issues/3#issuecomment-725343191