### PR TITLE
Enforce consistent hash shorthands

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -605,6 +605,7 @@ Style/HashLikeCase:
 
 Style/HashSyntax:
   Enabled: true
+  EnforcedShorthandSyntax: either
   EnforcedStyle: ruby19
 
 Style/HashTransformKeys:


### PR DESCRIPTION
I think consistent is better than enforced omitting: https://www.rubydoc.info/gems/rubocop/RuboCop/Cop/Style/HashSyntax