### PR TITLE
Disable Gemspec/OrderedDependencies

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -23,7 +23,7 @@ Gemspec/DuplicatedAssignment:
   Enabled: true
 
 Gemspec/OrderedDependencies:
-  Enabled: true
+  Enabled: false
 
 Gemspec/RequireMFA:
   Enabled: true


### PR DESCRIPTION
Often I want to sort gems logically and not alphabetically. And sometimes they need to be in a specific order, for various reasons. One example are js-bundling and css-bundling: js-bundling generates css and thus must be required first.