### PR TITLE
Disable Capybara/ClickLinkOrButtonStyle

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -458,6 +458,9 @@ RSpec/SortMetadata:
 RSpec/VerifiedDoubles:
   Enabled: false
 
+Capybara/ClickLinkOrButtonStyle:
+    Enabled: false
+
 Rails/ActionControllerFlashBeforeRender:
   Enabled: false
 

--- a/lib/renuocop/version.rb
+++ b/lib/renuocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Renuocop
-  VERSION = "0.4.1"
+  VERSION = "0.5.0"
 end


### PR DESCRIPTION
This cop will suggest to use `click_link` or `click_button` instead of the generic `click_on`

```
spec/system/deletion_request_spec.rb:11:3: C: Capybara/ClickLinkOrButtonStyle: Use click_link or click_button instead of click_on.00:23
  click_on I18n.t('new_deletion_request_modal.submit')00:23
  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
```

I disagree because I like to write my capybara tests as near as possible to the user experience. As a user, I have no idea if it's a link or a button, and it simply does not matter. I just click on it, whatever it is.
I therefore do not want to be specific about what I am actually clicking. On a system test level, it should not matter.