### PR TITLE
Fix usage instructions in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ inherit_gem:
 
 And then run it with
 
-    $ bundle exec renuocop
+    $ bundle exec rubocop
 
 ## Development
 


### PR DESCRIPTION
There isn't a renuocop binary available to run, we still need to run rubocop.