### PR TITLE
Exclude migrations from Rails/SkipsModelValidations check

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -426,6 +426,7 @@ Rails/WhereExists:
 Rails/SkipsModelValidations:
   Exclude:
     - 'spec/**/*.rb'
+    - 'db/migrate/*.rb'
 
 Security/IoMethods:
   Enabled: true


### PR DESCRIPTION
I'd disable this check altogether. 