### PR TITLE
Lift standardrb, add bin/check

### DIFF
--- a/bin/check
+++ b/bin/check
@@ -1,0 +1,3 @@
+!#/usr/bin/env bash
+
+bundle exec rake test

--- a/renuocop.gemspec
+++ b/renuocop.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-performance'
   spec.add_dependency 'rubocop-rails', '!= 2.20.0', '!= 2.20.1'
   spec.add_dependency 'rubocop-rspec'
-  spec.add_dependency 'standard', '> 1'
+  spec.add_dependency 'standard', '>= 1.35.1'
 
   # For more information and examples about making a new gem, check out our
   # guide at: https://bundler.io/guides/creating_gem.html


### PR DESCRIPTION
```
============================================================================
= WARNING: You do not want to run this version of Standard!                =
============================================================================

What's going on here?
---------------------
Version 1.35.0 of Standard was set to depend on `~> 1.62' of RuboCop. This
constraint is too loose, and covers all minor versions of RuboCop 1.x.

"How do I fix this?", you might be asking.

How to fix this
---------------
If you add a version specifier pinning `standard' to a version newer
than 1.35.1, Bundler will resolve appropriate versions of `standard',
`rubocop', and any other rubocop-dependent gems you may have installed.

1. Update your Gemfile to pin standard to be at least one such version:

  gem "standard", ">= 1.35.1"

2. Run `bundle`, which will install and lock more appropriate versions

  Example output:
    Using rubocop 1.48.1 (was 1.49.0)
    Using standard 1.26.0 (was 0.0.36)

This version (1.35.0.1) is an inoperative placeholder gem that exists
solely to print this message.

We're very sorry for this inconvenience!

============================================================================
=                         END OF BIG SCARY WARNING                         =
============================================================================
```