### PR TITLE
Change quotation rule

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## [0.8.0]
+
+- Finally change our default style from single quotes to double quotes
+
 ## [0.7.0]
 
 - Increase minimum standardrb version to 1.35.2

--- a/config/base.yml
+++ b/config/base.yml
@@ -701,12 +701,6 @@ Style/SpecialGlobalVars:
 Style/StringConcatenation:
   Enabled: true
 
-Style/StringLiterals:
-  EnforcedStyle: single_quotes
-
-Style/StringLiteralsInInterpolation:
-  EnforcedStyle: single_quotes
-
 Style/StructInheritance:
   Enabled: true
 

--- a/lib/renuocop/version.rb
+++ b/lib/renuocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Renuocop
-  VERSION = "0.7.0"
+  VERSION = "0.8.0"
 end


### PR DESCRIPTION
On 04.09.2024, during a very productive lunch break, we finally realized that everyone (sitting at the table) would prefer to use double-quotes. The fact that also standardrb and rails-rubocop-omakase prefer double-quotes makes this evenmore obvious.
We finally decided to switch.