### PR TITLE
Add array first last rule

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -443,6 +443,9 @@ Style/AccessorGrouping:
 Style/Alias:
   EnforcedStyle: prefer_alias
 
+Style/ArrayFirstLast:
+  Enabled: true
+
 Style/ArrayIntersect:
   Enabled: true
 


### PR DESCRIPTION
https://docs.rubocop.org/rubocop/cops_style.html#stylearrayfirstlast

```
# bad
arr[0]
arr[-1]

# good
arr.first
arr.last
arr[0] = 2
arr[0][-2]
```

I don't see a situation where we would prefer `arr[0]` or `arr[-1]` over `arr.first` and `arr.last`. Also `first` and `last` are more human readable.