### PR TITLE
Use compact `EnforcedStyle`

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -459,7 +459,7 @@ Style/CaseLikeIf:
   Enabled: true
 
 Style/ClassAndModuleChildren:
-  Enabled: true
+  EnforcedStyle: compact
 
 Style/ClassVars:
   Enabled: true


### PR DESCRIPTION
i propose [this](https://docs.rubocop.org/rubocop/cops_style.html#examples-styleclassandmodulechildren) because then we don't have to indent everything (less LOC, less whitespace), e.g.:
```rb
class Hotsheet::Generators::InstallGenerator < Rails::Generators::Base
  def mount_engine
    route "mount Hotsheet::Engine, at: :hotsheet"
  end
end
```
instead of
```rb
module Hotsheet
  module Generators
    class InstallGenerator < Rails::Generators::Base
      def mount_engine
        route "mount Hotsheet::Engine, at: :hotsheet"
      end
    end
  end
end
```