### PR TITLE
Use `rubocop-rspec_rails`

### DIFF
--- a/renuocop.gemspec
+++ b/renuocop.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency 'rubocop-factory_bot'
   spec.add_dependency 'rubocop-performance'
   spec.add_dependency 'rubocop-rails', '!= 2.20.0', '!= 2.20.1'
-  spec.add_dependency 'rubocop-rspec'
+  spec.add_dependency 'rubocop-rspec_rails'
   spec.add_dependency 'standard', '>= 1.35.1'
 
   # For more information and examples about making a new gem, check out our


### PR DESCRIPTION
rubocop notice:
```txt
Tip: Based on detected gems, the following RuboCop extension libraries might be helpful:
  * rubocop-rspec_rails (https://rubygems.org/gems/rubocop-rspec_rails)
```

`rubocop-rspec_rails` depends on `rubocop-rspec`