### PR TITLE
Exclude migrations from Linting

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -741,5 +741,6 @@ AllCops:
     - 'public/**/*'
     - 'tmp/**/*'
     - 'db/schema.rb'
+    - 'db/migrate/**/*'
     - 'vendor/**/*'
     - 'node_modules/**/*'


### PR DESCRIPTION
I don't understand why we would want to lint the migration files at all.
I would prefer to keep them as untouched as possible, so to not risk any changes/errors.

If I'm missing something here please lmk.