### PR TITLE
Revert "Exclude migrations from Linting"

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -745,6 +745,5 @@ AllCops:
     - 'public/**/*'
     - 'tmp/**/*'
     - 'db/schema.rb'
-    - 'db/migrate/**/*'
     - 'vendor/**/*'
     - 'node_modules/**/*'


### PR DESCRIPTION
Reverts renuo/renuocop#20

I'd like to keep this as for example there is a lint that checks whether the migration is reversible. See [docs.rubocop.org/rubocop-rails/cops_rails.html#railsreversiblemigration](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsreversiblemigration)