### PR TITLE
Refactor require to plugins

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.8.1]
+- Fix plugin inclusion warnings
+
 ## [0.8.0]
 
 - Finally change our default style from single quotes to double quotes

--- a/config/base.yml
+++ b/config/base.yml
@@ -1,10 +1,12 @@
+require:
+  - standard
+
 plugins:
   - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-performance
   - rubocop-rails
-  - rubocop-rspec
-  - standard
+  - rubocop-rspec  
 
 inherit_gem:
   standard: config/base.yml

--- a/config/base.yml
+++ b/config/base.yml
@@ -1,4 +1,4 @@
-require:
+plugins:
   - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-performance

--- a/lib/renuocop/version.rb
+++ b/lib/renuocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Renuocop
-  VERSION = "0.8.0"
+  VERSION = "0.8.1"
 end


### PR DESCRIPTION
#  Refactor require to plugins

Before, `require` was used for plugin inclusion, when `plugins` should have been used instead. This lead to the following warnings when renuocop was run:

```log
rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of `require: rubocop-rspec` in /Users/dani/renuo/projects/herold-planner/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-rails extension supports plugin, specify `plugins: rubocop-rails` instead of `require: rubocop-rails` in /Users/dani/renuo/projects/herold-planner/.rubocop.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-capybara extension supports plugin, specify `plugins: rubocop-capybara` instead of `require: rubocop-capybara` in /Users/dani/.asdf/installs/ruby/3.2.7/lib/ruby/gems/3.2.0/gems/renuocop-0.8.0/config/base.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-factory_bot extension supports plugin, specify `plugins: rubocop-factory_bot` instead of `require: rubocop-factory_bot` in /Users/dani/.asdf/installs/ruby/3.2.7/lib/ruby/gems/3.2.0/gems/renuocop-0.8.0/config/base.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-performance extension supports plugin, specify `plugins: rubocop-performance` instead of `require: rubocop-performance` in /Users/dani/.asdf/installs/ruby/3.2.7/lib/ruby/gems/3.2.0/gems/renuocop-0.8.0/config/base.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-rails extension supports plugin, specify `plugins: rubocop-rails` instead of `require: rubocop-rails` in /Users/dani/.asdf/installs/ruby/3.2.7/lib/ruby/gems/3.2.0/gems/renuocop-0.8.0/config/base.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.

rubocop-rspec extension supports plugin, specify `plugins: rubocop-rspec` instead of `require: rubocop-rspec` in /Users/dani/.asdf/installs/ruby/3.2.7/lib/ruby/gems/3.2.0/gems/renuocop-0.8.0/config/base.yml.
For more information, see https://docs.rubocop.org/rubocop/plugin_migration_guide.html.
```