### PR TITLE
Load rubocop rspec rails

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.8.2]
+- Load `rubocop-rspec_rails` plugin by default
+
 ## [0.8.1]
 - Fix plugin inclusion warnings
 

--- a/config/base.yml
+++ b/config/base.yml
@@ -5,8 +5,9 @@ plugins:
   - rubocop-capybara
   - rubocop-factory_bot
   - rubocop-performance
+  - rubocop-rspec
+  - rubocop-rspec_rails
   - rubocop-rails
-  - rubocop-rspec  
 
 inherit_gem:
   standard: config/base.yml

--- a/lib/renuocop/version.rb
+++ b/lib/renuocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Renuocop
-  VERSION = "0.8.1"
+  VERSION = "0.8.2"
 end

--- a/renuocop.gemspec
+++ b/renuocop.gemspec
@@ -34,6 +34,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "rubocop-factory_bot"
   spec.add_dependency "rubocop-performance"
   spec.add_dependency "rubocop-rails", "!= 2.20.0", "!= 2.20.1"
+  spec.add_dependency "rubocop-rspec"
   spec.add_dependency "rubocop-rspec_rails"
   spec.add_dependency "standard", ">= 1.35.1"
 


### PR DESCRIPTION
https://github.com/renuo/renuocop/pull/18 follow up

```
The following RuboCop extension libraries are installed but not loaded in config:
  * rubocop-rspec_rails

You can opt out of this message by adding the following to your config (see https://docs.rubocop.org/rubocop/extensions.html#extension-suggestions for more options):
  AllCops:
    SuggestExtensions: false
```