### PR TITLE
Disable NegationBeValid cop

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -407,6 +407,9 @@ RSpec/SortMetadata:
 RSpec/VerifiedDoubles:
   Enabled: false
 
+RSpecRails/NegationBeValid:
+  Enabled: false
+
 Capybara/ClickLinkOrButtonStyle:
     Enabled: false
 


### PR DESCRIPTION
Disables https://github.com/rubocop/rubocop-rspec/pull/1665

![CleanShot 2025-06-03 at 08 45 03@2x](https://github.com/user-attachments/assets/d9ca31a9-e871-46bb-9642-193c1aedf1b9)

I don't think one or the other form is better. I am fine in having both and using both.