### PR TITLE
Rename `Naming/PredicateName` to `Naming/PredicatePrefix`

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -285,7 +285,7 @@ Naming/MethodName:
 Naming/MethodParameterName:
   Enabled: true
 
-Naming/PredicateName:
+Naming/PredicatePrefix:
   Enabled: true
 
 Naming/RescuedExceptionsVariableName:


### PR DESCRIPTION
`Warning: The Naming/PredicateName cop has been renamed to Naming/PredicatePrefix.`