### PR TITLE
Disable Rails/FindByOrAssignmentMemoization rule

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -438,6 +438,9 @@ Rails/SkipsModelValidations:
     - 'spec/**/*.rb'
     - 'db/migrate/*.rb'
 
+Rails/FindByOrAssignmentMemoization:
+  Enabled: false
+
 Security/IoMethods:
   Enabled: true
 


### PR DESCRIPTION
A new [rule](https://docs.rubocop.org/rubocop-rails/cops_rails.html#railsfindbyorassignmentmemoization) was added to the set, which aims to make memoization more robust when using ActiveRecord's `find_by` method.

It essentially points out cases like [this (cobra)](https://github.com/renuo/cobra/pull/1918/commits/9e488574111abc69aa94d3f1ef5d0adc6906ea1c) and [this (fredi)](https://github.com/renuo/fredi/pull/1898/commits/aab4d452dcdd2d398d0dcee5049087176d36dab0), where it aims to ensure that memoization is truly doing what it's intended – ensuring that the query is run only once.

After a short discussion with @coorasse, I'm not sure this subtlety is worth the double (or even worse, 5x) lines of code. Yes, some queries could be ran more than once unnecessarily depending on how often the memoized variable is used, but queries should be cached anyway, which doesn't hinder performance. For this reason, we'd suggest disabling this rule in general.

I personally feel it doesn't bring much to the table, but I'm curious if you see things differently!