### PR TITLE
Add CountAsOne option to Metrics/BlockLength cop

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## [0.8.7]
+- Add `CountAsOne` option to `Metrics/BlockLength` cop
+
 ## [0.8.6]
 - Set `Layout/FirstArrayElementIndentation` and `Layout/FirstHashElementIndentation` to `consistent`
 

--- a/config/base.yml
+++ b/config/base.yml
@@ -212,15 +212,15 @@ Metrics/AbcSize:
 
 Metrics/BlockLength:
   Enabled: true
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
   Exclude:
     - 'spec/**/*.rb'
     - 'config/environments/**/*.rb'
     - 'config/routes.rb'
     - 'db/**/*'
-  CountAsOne:
-    - array
-    - hash
-    - heredoc
 
 Metrics/BlockNesting:
   Enabled: true
@@ -239,12 +239,12 @@ Metrics/CyclomaticComplexity:
 
 Metrics/MethodLength:
   Enabled: true
-  Exclude:
-    - 'spec/system/**/*.rb'
   CountAsOne:
     - array
     - hash
     - heredoc
+  Exclude:
+    - 'spec/system/**/*.rb'
 
 Metrics/ModuleLength:
   Enabled: true

--- a/config/base.yml
+++ b/config/base.yml
@@ -217,6 +217,10 @@ Metrics/BlockLength:
     - 'config/environments/**/*.rb'
     - 'config/routes.rb'
     - 'db/**/*'
+  CountAsOne:
+    - array
+    - hash
+    - heredoc
 
 Metrics/BlockNesting:
   Enabled: true

--- a/lib/renuocop/version.rb
+++ b/lib/renuocop/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Renuocop
-  VERSION = "0.8.6"
+  VERSION = "0.8.7"
 end


### PR DESCRIPTION
Currently, only [`Metrics/ClassLength`](https://docs.rubocop.org/rubocop/cops_metrics.html#metricsclasslength), [`Metrics/MethodLength`](https://docs.rubocop.org/rubocop/cops_metrics.html#metricsmethodlength), and [`Metrics/ModuleLength`](https://docs.rubocop.org/rubocop/cops_metrics.html#metricsmodulelength) all have the `CountAsOne` option enabled with arrays, hashes, and heredoc.
This PR also adds it to the [`Metrics/BlockLength` cop](https://docs.rubocop.org/rubocop/cops_metrics.html#metricsblocklength), which comes in handy when using DSLs.

<details>
<summary>Example</summary>

**This currently counts as 11 lines**
```rb
something do
  array = [
    1,
    2
  ]

  hash = {
    key: 'value'
  }

  msg = <<~HEREDOC
    Heredoc
    content.
  HEREDOC
end
```


**This already only counts as 4 lines**
```rb
def something
  array = [
    1,
    2
  ]

  hash = {
    key: 'value'
  }

  msg = <<~HEREDOC
    Heredoc
    content.
  HEREDOC
end
```

</details>
