### PR TITLE
Remove GuardClause cop

### DIFF
--- a/config/base.yml
+++ b/config/base.yml
@@ -541,9 +541,6 @@ Style/FormatStringToken:
 Style/FrozenStringLiteralComment:
   Enabled: true
 
-Style/GuardClause:
-  Enabled: true
-
 Style/HashEachMethods:
   Enabled: true
 


### PR DESCRIPTION
Step by step, year after year, moving towards standard. This cop forces us to write code I heavily disagree with, for example I want to write this:

```ruby
can :switch, Tenant
can :resubmit, Workflow
can %i[create], IbmDocument

if ENABLE_SIMULATORS # offense
  can :create, FakeOnboarding
  can :read, :pdfs
end
```

but the cop want me to write:

```ruby
can :switch, Tenant
can :resubmit, Workflow
can %i[create], IbmDocument

return unless ENABLE_SIMULATORS
can :create, FakeOnboarding
can :read, :pdfs
```

which is considerably more dangerous. Guard clases should be used only at the beginning of a method. 
cc @edmunteanu 